### PR TITLE
Add unit test for Mark action (#36)

### DIFF
--- a/pkg/brain/brain.go
+++ b/pkg/brain/brain.go
@@ -9,6 +9,13 @@ import (
 	"github.com/go-redis/redis"
 )
 
+type BrainInterface interface {
+	Set(key string, val interface{}) error
+	Read(key string) (string, error)
+	Get(key string, q interface{}) error
+	Close() error
+}
+
 type Brain struct {
 	client *redis.Client
 }

--- a/pkg/slackbot/slackbot.go
+++ b/pkg/slackbot/slackbot.go
@@ -83,3 +83,28 @@ func (bot *Bot) HandleMsg(channel, username, text string) {
 		bot.defact(bot, msg, user)
 	}
 }
+
+func (bot *Bot) FindUser(user string) *slack.User {
+	if strings.HasPrefix(user, "<@") {
+		user = strings.Trim(user, "<@>")
+		u, err := bot.Client.GetUserInfo(user)
+		if err != nil {
+			log.Println(err)
+			return nil
+		}
+		return u
+	}
+
+	users, err := bot.Client.GetUsers()
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	for _, u := range users {
+		if strings.ToLower(u.Name) == strings.ToLower(user) {
+			return &u
+		}
+	}
+	return nil
+}

--- a/pkg/slackbot/slackbot.go
+++ b/pkg/slackbot/slackbot.go
@@ -14,8 +14,17 @@ type BotMsg struct {
 	Text    string
 }
 
-type SimpleAction func(*Bot, *BotMsg, *slack.User)
-type Action func(*Bot, *BotMsg, *slack.User, ...string)
+type SimpleAction func(BotInterface, *BotMsg, *slack.User)
+type Action func(BotInterface, *BotMsg, *slack.User, ...string)
+
+type BotInterface interface {
+	RespondTo(match string, action Action)
+	DefaultResponse(action SimpleAction)
+	Message(channel string, msg string)
+	HandleMsg(channel, username, text string)
+	FindUser(user string) *slack.User
+	OpenDirectChannel(user string) (string, error)
+}
 
 type Bot struct {
 	UserID string

--- a/pkg/slackbot/slackbot.go
+++ b/pkg/slackbot/slackbot.go
@@ -108,3 +108,11 @@ func (bot *Bot) FindUser(user string) *slack.User {
 	}
 	return nil
 }
+
+func (bot *Bot) OpenDirectChannel(user string) (string, error) {
+	_, _, ch, err := bot.Client.OpenIMChannel(user)
+	if err != nil {
+		return "", err
+	}
+	return ch, nil
+}

--- a/pkg/tinabot/cron.go
+++ b/pkg/tinabot/cron.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-redis/redis"
 )
 
-func (t *TinaBot) Cron(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+func (t *TinaBot) Cron(bot slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 
 	var crontab []string
 	if args[1] != "" {

--- a/pkg/tinabot/for.go
+++ b/pkg/tinabot/for.go
@@ -81,7 +81,7 @@ func (t *TinaBot) For(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User,
 		finduser := bot.FindUser(dest)
 		if finduser != nil {
 			destUser = User{finduser.Name, finduser.ID}
-			_, _, ch, err := bot.Client.OpenIMChannel(destUser.ID)
+			ch, err := bot.OpenDirectChannel(destUser.ID)
 			if err != nil {
 				log.Println(err)
 			} else {

--- a/pkg/tinabot/for.go
+++ b/pkg/tinabot/for.go
@@ -70,7 +70,7 @@ func findDishes(menu tuttobene.Menu, dish string) []tuttobene.MenuRow {
 	return matches
 }
 
-func (t *TinaBot) For(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+func (t *TinaBot) For(bot slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 	dest := args[1]
 	dish := sanitize(args[2])
 

--- a/pkg/tinabot/for.go
+++ b/pkg/tinabot/for.go
@@ -70,31 +70,6 @@ func findDishes(menu tuttobene.Menu, dish string) []tuttobene.MenuRow {
 	return matches
 }
 
-func getUserInfo(api *slack.Client, user string) *slack.User {
-	if strings.HasPrefix(user, "<@") {
-		user = strings.Trim(user, "<@>")
-		u, err := api.GetUserInfo(user)
-		if err != nil {
-			log.Println(err)
-			return nil
-		}
-		return u
-	}
-
-	users, err := api.GetUsers()
-	if err != nil {
-		log.Println(err)
-		return nil
-	}
-
-	for _, u := range users {
-		if strings.ToLower(u.Name) == strings.ToLower(user) {
-			return &u
-		}
-	}
-	return nil
-}
-
 func (t *TinaBot) For(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 	dest := args[1]
 	dish := sanitize(args[2])
@@ -103,7 +78,7 @@ func (t *TinaBot) For(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User,
 	destCh := ""
 
 	if strings.ToLower(dest) != "me" {
-		finduser := getUserInfo(t.bot.Client, dest)
+		finduser := bot.FindUser(dest)
 		if finduser != nil {
 			destUser = User{finduser.Name, finduser.ID}
 			_, _, ch, err := bot.Client.OpenIMChannel(destUser.ID)
@@ -155,7 +130,7 @@ func (t *TinaBot) For(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User,
 			t.bot.Message(msg.Channel, fmt.Sprintf("E' necessario specificare da chi vuoi copiare l'ordine"))
 			return
 		}
-		finduser := getUserInfo(t.bot.Client, l[1])
+		finduser := bot.FindUser(l[1])
 		name := User{Name: l[1], ID: ""}
 		if finduser != nil {
 			name = User{finduser.Name, finduser.ID}

--- a/pkg/tinabot/mark.go
+++ b/pkg/tinabot/mark.go
@@ -48,7 +48,7 @@ func MarkUser(user *slack.User, food string) error {
 	return errors.New("user does not have a Develer mail")
 }
 
-func (t *TinaBot) Mark(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+func (t *TinaBot) Mark(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 	food := strings.TrimSpace(args[1])
 
 	validFood := []string{

--- a/pkg/tinabot/order_test.go
+++ b/pkg/tinabot/order_test.go
@@ -33,7 +33,7 @@ func TestOrder(t *testing.T) {
 	uclist2 := []UserChoice{uc3}
 	order.Set(User{"test", "123"}, uclist)
 	assertEqual(t, order.String(), "1 primo [test]\n1 secondo [test]", "")
-	assertEqual(t, order.Format(false), "1 primo\n1 secondo", "")
+	assertEqual(t, order.Format(false, false), "1 primo\n1 secondo", "")
 	order.Set(User{"test2", "456"}, uclist)
 	assertEqual(t, order.String(), "2 primo [test, test2]\n2 secondo [test, test2]", "")
 	order.Set(User{"test3", "789"}, uclist2)

--- a/pkg/tinabot/remind.go
+++ b/pkg/tinabot/remind.go
@@ -39,7 +39,7 @@ func formatReminder(mask int) string {
 	return reply
 }
 
-func (t *TinaBot) Remind(bot *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+func (t *TinaBot) Remind(bot slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 	weekMask := map[string]int{
 		"off": 0,
 		"dis": 0,

--- a/pkg/tinabot/tinabot.go
+++ b/pkg/tinabot/tinabot.go
@@ -164,7 +164,7 @@ func (t *TinaBot) AddCommands() {
 	t.bot.RespondTo("^(?i)rmorder (.*)$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		u := args[1]
 		name := User{u, ""}
-		finduser := getUserInfo(b.Client, u)
+		finduser := t.bot.FindUser(u)
 		if finduser != nil {
 			name = User{finduser.Name, finduser.ID}
 		}

--- a/pkg/tinabot/tinabot.go
+++ b/pkg/tinabot/tinabot.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-redis/redis"
 )
 
-func getOrder(brain *brain.Brain) *Order {
+func getOrder(brain brain.BrainInterface) *Order {
 	var order Order
 
 	if order.Load(brain) != nil {
@@ -37,43 +37,47 @@ func sanitize(s string) string {
 }
 
 type TinaBot struct {
-	bot   *slackbot.Bot
-	brain *brain.Brain
+	bot   slackbot.BotInterface
+	brain brain.BrainInterface
 }
 
-func New(bot *slackbot.Bot, b *brain.Brain) *TinaBot {
+func New(bot slackbot.BotInterface, b brain.BrainInterface) *TinaBot {
 	return &TinaBot{bot, b}
+}
+
+func (t *TinaBot) AddCommand(match string, action slackbot.Action) {
+	t.bot.RespondTo(match, action)
 }
 
 func (t *TinaBot) AddCommands() {
 
-	t.bot.DefaultResponse(func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User) {
+	t.bot.DefaultResponse(func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User) {
 		t.bot.Message(msg.Channel, "Mi dispiace "+user.Name+", purtroppo non posso farlo.\nProva con `aiuto` per vedere l'elenco delle cose che posso fare.")
 	})
 
-	t.bot.RespondTo("^(?i)(help|aiut).*$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)(help|aiut).*$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		t.bot.Message(msg.Channel, strings.Replace(HelpStr, "‘", "`", -1))
 	})
 
 	t.bot.RespondTo("^(?i)per (\\S+) (.*)$", t.For)
 
-	t.bot.RespondTo("^(?i)ordine$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)ordine$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		order := getOrder(t.brain)
 		t.bot.Message(msg.Channel, "Ecco l'ordine:\n"+order.String())
 	})
 
-	t.bot.RespondTo("^(?i)conto$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)conto$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		order := getOrder(t.brain)
 		t.bot.Message(msg.Channel, "Ecco il conto:\n"+order.Bill())
 	})
 
-	t.bot.RespondTo("^(?i)cancella ordine$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)cancella ordine$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		order := NewOrder()
 		order.Save(t.brain)
 		t.bot.Message(msg.Channel, "Ordine cancellato")
 	})
 
-	t.bot.RespondTo("^(?i)email$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)email$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		order := getOrder(t.brain)
 		subj := "Ordine Develer del giorno " + order.Timestamp.Format("02/01/2006")
 		body := order.Format(false, false)
@@ -86,7 +90,7 @@ func (t *TinaBot) AddCommands() {
 		t.bot.Message(msg.Channel, out)
 	})
 
-	t.bot.RespondTo("^(?i)menu([\\s\\S]*)?", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)menu([\\s\\S]*)?", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 
 		showPrices := false
 
@@ -106,7 +110,7 @@ func (t *TinaBot) AddCommands() {
 		}
 	})
 
-	t.bot.RespondTo("^(?i)setmenu([\\s\\S]*)?", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)setmenu([\\s\\S]*)?", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		if args[1] != "" {
 			menu := strings.Split(strings.TrimSpace(sanitize(args[1])), "\n")
 			m, err := tuttobene.ParseMenuCells(menu, []string{})
@@ -121,7 +125,7 @@ func (t *TinaBot) AddCommands() {
 		}
 	})
 
-	t.bot.RespondTo("^set (.*)$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^set (.*)$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		ar := strings.Split(args[1], " ")
 		key := ar[0]
 		val := ar[1]
@@ -133,7 +137,7 @@ func (t *TinaBot) AddCommands() {
 		}
 	})
 
-	t.bot.RespondTo("^get (.*)$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^get (.*)$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		key := args[1]
 		var val string
 		err := t.brain.Get(key, &val)
@@ -144,7 +148,7 @@ func (t *TinaBot) AddCommands() {
 		}
 	})
 
-	t.bot.RespondTo("^read (.*)$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^read (.*)$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		key := args[1]
 
 		val, err := t.brain.Read(key)
@@ -161,7 +165,7 @@ func (t *TinaBot) AddCommands() {
 
 	t.bot.RespondTo("^(?i)segna(.*)$", t.Mark)
 
-	t.bot.RespondTo("^(?i)rmorder (.*)$", func(b *slackbot.Bot, msg *slackbot.BotMsg, user *slack.User, args ...string) {
+	t.bot.RespondTo("^(?i)rmorder (.*)$", func(b slackbot.BotInterface, msg *slackbot.BotMsg, user *slack.User, args ...string) {
 		u := args[1]
 		name := User{u, ""}
 		finduser := t.bot.FindUser(u)

--- a/pkg/tinabot/tinabot_test.go
+++ b/pkg/tinabot/tinabot_test.go
@@ -1,7 +1,16 @@
 package tinabot
 
 import (
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/develersrl/lunches/pkg/slackbot"
+	"github.com/nlopes/slack"
 )
 
 func TestSplitSep(t *testing.T) {
@@ -28,5 +37,137 @@ func TestSplitSep(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func getTestUserProfile() slack.UserProfile {
+	return slack.UserProfile{
+		StatusText:            "testStatus",
+		StatusEmoji:           ":construction:",
+		RealName:              "Test Real Name",
+		RealNameNormalized:    "Test Real Name Normalized",
+		DisplayName:           "Test Display Name",
+		DisplayNameNormalized: "Test Display Name Normalized",
+		Email:                 "test@develer.com",
+		Image24:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_24.jpg",
+		Image32:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_32.jpg",
+		Image48:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_48.jpg",
+		Image72:               "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_72.jpg",
+		Image192:              "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2016-10-18/92962080834_ef14c1469fc0741caea1_192.jpg",
+		Fields:                slack.UserProfileCustomFields{},
+	}
+}
+
+func NewMockSlackUser(username string) *slack.User {
+	return &slack.User{
+		ID:                "UXXXXXXXX",
+		Name:              username,
+		Deleted:           false,
+		Color:             "9f69e7",
+		RealName:          "testuser",
+		TZ:                "America/Los_Angeles",
+		TZLabel:           "Pacific Daylight Time",
+		TZOffset:          -25200,
+		Profile:           getTestUserProfile(),
+		IsBot:             false,
+		IsAdmin:           false,
+		IsOwner:           false,
+		IsPrimaryOwner:    false,
+		IsRestricted:      false,
+		IsUltraRestricted: false,
+		Has2FA:            false,
+	}
+}
+
+type MockBrain struct{}
+
+func (b MockBrain) Set(key string, val interface{}) error {
+	return nil
+}
+func (b MockBrain) Read(key string) (string, error) {
+	return "", nil
+}
+
+func (b MockBrain) Get(key string, q interface{}) error {
+	return nil
+}
+
+func (b MockBrain) Close() error {
+	return nil
+}
+
+type SentMessage struct {
+	channel string
+	message string
+}
+
+type MockBot struct {
+	actions  map[*regexp.Regexp]slackbot.Action
+	defact   slackbot.SimpleAction
+	messages []SentMessage
+}
+
+func NewMockBot() *MockBot {
+	return &MockBot{
+		actions:  make(map[*regexp.Regexp]slackbot.Action),
+		messages: make([]SentMessage, 0, 1),
+	}
+}
+
+func (b *MockBot) RespondTo(match string, action slackbot.Action) {
+	b.actions[regexp.MustCompile(match)] = action
+}
+func (b *MockBot) DefaultResponse(action slackbot.SimpleAction) {
+	b.defact = action
+}
+func (b *MockBot) Message(channel string, msg string) {
+	b.messages = append(b.messages, SentMessage{channel, msg})
+}
+func (b *MockBot) HandleMsg(channel, username, text string) {
+	msg := &slackbot.BotMsg{channel, username, text}
+	txt := strings.TrimLeft(strings.TrimSpace(text), "<@"+username+"> ")
+	user := NewMockSlackUser(username)
+	for match, action := range b.actions {
+		if matches := match.FindAllStringSubmatch(txt, -1); matches != nil {
+			action(b, msg, user, matches[0]...)
+			return
+		}
+	}
+
+	if b.defact != nil {
+		b.defact(b, msg, user)
+	}
+}
+func (b *MockBot) FindUser(user string) *slack.User {
+	return nil
+}
+func (b *MockBot) OpenDirectChannel(user string) (string, error) {
+	return "", nil
+}
+
+func TestCommands(t *testing.T) {
+	// setup
+	bot := NewMockBot()
+	tina := New(bot, &MockBrain{})
+	tina.AddCommands()
+	url := "http://localhost:9998"
+	os.Setenv("MARK_URL", url)
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "OK")
+	})
+	go http.ListenAndServe(url, nil)
+
+	// action
+	tina.bot.HandleMsg("chat_cibo", "pippo", "segna PD")
+	// we have to wait because the Mark action happens in another goroutine
+	// is there a better way to handle this case?
+	time.Sleep(300 * time.Millisecond)
+
+	// assert
+	if len(bot.messages) != 1 {
+		t.Error("Received no messages")
+	}
+	if strings.Index(bot.messages[0].message, "Ok") == -1 {
+		t.Errorf("Received error: %v", bot.messages[0].message)
 	}
 }


### PR DESCRIPTION
This PR adds the first unit test for actions, the Mark action for which there is an open issue (#36 )
The first 3 commits are fixes of existing tests and general refactoring to allow easier testing.

The last commit adds interfaces for Bot and Brain and adds the test for the Mark action.

I have the feeling that logically the method `Bot.HandleMsg` could be moved to `Tinabot`, but it still depends on `slackbot.Client` so it's not immediate. One idea is the following:

* Move `HandleMsg` to `Tinabot`;
* Add a method `BotInterface.GetUserInfo` to be able to mock the call on line 78;

Without that refactor, I had to copy most of `Bot.HandleMsg` into `MockBot.HandleMsg`, which is *far* from ideal :smile: 